### PR TITLE
[Jenkins]: Fix rebuild route and project depth in view runs route

### DIFF
--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -344,15 +344,8 @@ export class JenkinsApiImpl {
 
   async getJobBuilds(jenkinsInfo: JenkinsInfo, jobFullName: string) {
     let jobName = jobFullName;
-
     if (jobFullName.includes('/')) {
-      const arr = jobFullName.split('/');
-      const multibranchJobName = arr.shift();
-      jobName = [
-        multibranchJobName,
-        'job',
-        encodeURIComponent(arr.join('/')),
-      ].join('/');
+      jobName = jobFullName.split('/').map((s: string) => `${encodeURIComponent(s)}`).join('/job/');
     }
 
     const response = await fetch(
@@ -369,7 +362,6 @@ export class JenkinsApiImpl {
     );
 
     const jobBuilds = await response.json();
-
     return jobBuilds;
   }
 }

--- a/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
@@ -208,9 +208,9 @@ export class JenkinsClient implements JenkinsApi {
       entity.kind,
     )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
       jobFullName,
-    )}/${encodeURIComponent(buildNumber)}:rebuild`;
+    )}/${encodeURIComponent(buildNumber)}`;
 
-    const response = await this.fetchApi.fetch(url);
+    const response = await this.fetchApi.fetch(url, {method: "POST"});
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On jenkins community backend plugin:
1. Rebuild route ❌
   `const response = await this.fetchApi.fetch(url);`
     In backend, the rebuild route was created with POST method but frontend was calling with GET.
   
2. View runs route ❌
     `const arr = jobFullName.split('/');
      const multibranchJobName = arr.shift();
      jobName = [
        multibranchJobName,
        'job',
        encodeURIComponent(arr.join('/')),
      ].join('/');`
      The above code was not correctly written for job depth more than 1 from root.
    
## Multibranch pipeline job on root
### Jenkins Latest Run Card
<img width="737" alt="Screenshot 2024-07-30 at 7 14 38 PM" src="https://github.com/user-attachments/assets/ef4b32a2-0f89-4c14-947d-19de3bdc2309">

### Jenkins Content Card
<img width="1500" alt="Screenshot 2024-07-30 at 7 15 15 PM" src="https://github.com/user-attachments/assets/5f048bc6-24e5-4a33-b066-dfe39bd405aa">

### Jenkins View Runs table
<img width="1490" alt="Screenshot 2024-07-30 at 7 15 32 PM" src="https://github.com/user-attachments/assets/fec58e8d-fe42-40e1-8a6d-8cdb9b23f970">



- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
